### PR TITLE
PHPCompat: remove PHP4-style constructor

### DIFF
--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -475,8 +475,6 @@ class WP_Categories_to_Tags extends WP_Importer {
 
 		$this->footer();
 	}
-
-	function WP_Categories_to_Tags() { /* Do nothing. */ }
 }
 
 $wp_cat2tag_importer = new WP_Categories_to_Tags();


### PR DESCRIPTION
PHP 4-style constructors where the constructor function name mirrors the class name have been deprecated since PHP 7.0 and support has been removed since PHP 8.0, which means they are now silently ignored.

Considering the constructor is empty and is overloading an equally [empty constructor in the `WP_Importer` class](https://developer.wordpress.org/reference/classes/wp_importer/), I'm fixing this by removing the method.

This should not be considered a BC-break as calling the constructor directly on an instantiated object was never the intention of the code anyway and instantiating the object via `new WP_Categories_to_Tags()` will now fall through to the parent constructor, which equally does nothing anyway.

Refs:
* https://wiki.php.net/rfc/remove_php4_constructors