### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Categories to Tags Converter ===
 Contributors: wordpressdotorg
-Donate link: 
+Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 4.1
-Stable tag: 0.5
+Tested up to: 6.1
+Stable tag: 0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,8 +22,20 @@ Convert existing categories to tags or tags to categories, selectively.
 
 == Changelog ==
 
+= 0.6 =
+* Add support for WordPress 6.1
+
 = 0.5 =
-* Fix issue where WordPress could not load the importer.
+* Fix issue where WordPress could not load the importer
+
+= 0.4 =
+* Fixes #WP13460
+
+= 0.3 =
+* Change handle to match plugin slug
+
+= 0.2 =
+* Add WP_LOAD_IMPORTERS check
 
 = 0.1 =
 * Initial release

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.5.2
+Version: 0.6.0
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -54,7 +54,11 @@ class WP_Categories_to_Tags extends WP_Importer {
 			$tabs['formats'] = array( 'label' => __( 'Formats', 'wpcat2tag-importer' ), 'url' => admin_url( 'admin.php?import=wpcat2tag&tab=formats' ) ); ?>
 
 		<div class="wrap">
-		<?php screen_icon(); ?>
+		<?php
+			if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+				screen_icon();
+			}
+		?>
 		<h2><?php _e( 'Categories, Tags and Formats Converter', 'wpcat2tag-importer' ); ?></h2>
 		<h3 class="nav-tab-wrapper">
 		<?php foreach ( $tabs as $tab => $info ) :
@@ -248,7 +252,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 		$convert_to = 'tag' == $_POST['convert_to'] ? 'post_tag' : 'category';
 		if ( ! $term_info = term_exists( $_POST['convert_to_slug'], $convert_to ) )
 			$term_info = wp_insert_term( $_POST['convert_to_slug'], $convert_to );
-			
+
 		if ( is_wp_error($term_info) ) {
 			echo '<p>' . $term_info->get_error_message() . ' ';
 			printf( __( 'Please <a href="%s">try again</a>.', 'wpcat2tag-importer' ), 'admin.php?import=wpcat2tag&amp;tab=cats' ) . "</p>\n";
@@ -307,7 +311,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 			echo '</div>';
 			return;
 		}
-		
+
 		$default = get_option( 'default_category' );
 
 		if ( ! isset($_POST['convert_to']) || 'format' != $_POST['convert_to'] ) {
@@ -337,7 +341,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 				if ( 'post_tag' == $convert_to ) {
 					if ( ! $term_info = term_exists( $category->slug, 'post_tag' ) )
 						$term_info = wp_insert_term( $category->name, 'post_tag', array( 'description' => $category->description ) );
-						
+
 					if ( is_wp_error($term_info) ) {
 						echo $term_info->get_error_message() . "</li>\n";
 						continue;
@@ -351,7 +355,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 						$values[] = $wpdb->prepare( "(%d, %d, 0)", $post, $term_info['term_taxonomy_id'] );
 						clean_post_cache( $post );
 					}
-					
+
 					$wpdb->query( "INSERT INTO {$wpdb->term_relationships} (object_id, term_taxonomy_id, term_order) VALUES " . join(',', $values) );
 					$wpdb->update( $wpdb->term_taxonomy, array( 'count' => $category->count ), array( 'term_id' => $term_info['term_id'], 'taxonomy' => $convert_to ) );
 				// otherwise just convert it
@@ -404,7 +408,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 				if ( 'category' == $convert_to ) {
 					if ( ! $term_info = term_exists( $tag->slug, 'category' ) )
 						$term_info = wp_insert_term( $tag->name, 'category', array( 'description' => $tag->description ) );
-						
+
 					if ( is_wp_error($term_info) ) {
 						echo $term_info->get_error_message() . "</li>\n";
 						continue;

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.6.0
+Version: 0.6
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -55,7 +55,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 
 		<div class="wrap">
 		<?php
-			if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 				screen_icon();
 			}
 		?>


### PR DESCRIPTION
The "Categories to Tags Converter Importer" seems to work like a charm in WordPress 6.1 and lower. I've only added a couple of fixes for PHP >7, and missing history.
See also: https://github.com/WordPress/wpcat2tag-importer/pull/1

1. Tested with WordPress `6.1`
2. Tested with PHP `7.4.33`

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **Categories to Tags Converter Importer**
5. Activate a theme that supports post format: http://localhost/wp-admin/theme-install.php (filter with: Features -> "Post Formats")
6. Create some tags, some categories, and some posts tagged with that
7. Open `http://localhost/wp-admin/admin.php?import=wpcat2tag`
8. Try to convert tags to categories, categories to tags and etc. The plugin must load correctly and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/wpcat2tag-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```