### PR TITLE
Test plugin for WordPress 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
 Tested up to: 6.2
-Stable tag: 0.6.1
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ Convert existing categories to tags or tags to categories, selectively.
 
 == Changelog ==
 
+= 0.6.2 =
+* Testing the plugin up to WordPress 6.3
+
 = 0.6.1 =
 * Testing the plugin up to WordPress 6.2
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 6.2
-Stable tag: 0.6.2
+Tested up to: 6.3
+Stable tag: 0.6.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,9 +21,6 @@ Convert existing categories to tags or tags to categories, selectively.
 1. Go to the Tools -> Import screen, Click on Categories and Tags Converter
 
 == Changelog ==
-
-= 0.6.2 =
-* Testing the plugin up to WordPress 6.3
 
 = 0.6.1 =
 * Testing the plugin up to WordPress 6.2

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.1
+Version: 0.6.2
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.2
+Version: 0.6.1
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 


### PR DESCRIPTION
In this PR, we test the plugin for WordPress 6.3.

## How to test

1. Clone this PR
2. Using `wp-env` run an instance. The minimum PHP version is 7.0 because WordPress 6.3 [dropped support for PHP 5](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).
3. Install the WordPress Importer plugin
4. `composer install`
5. Create some categories, tags and post formats (you need to install a theme that supports post formats).
6. Go to `http://localhost:8888/wp-admin/admin.php?import=wpcat2tag` and perform an import.
7. Check if the content has been imported and no errors are being generated.