### PR TITLE
Update tested up to label and stable tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 6.3
-Stable tag: 0.6.1
+Tested up to: 6.4.2
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ Convert existing categories to tags or tags to categories, selectively.
 1. Go to the Tools -> Import screen, Click on Categories and Tags Converter
 
 == Changelog ==
+
+= 0.6.2 =
+* Testing the plugin up to WordPress 6.4.2
+* Update link references from http to https.
 
 = 0.6.1 =
 * Testing the plugin up to WordPress 6.2

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.1
+Version: 0.6.2
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 


### PR DESCRIPTION
- This PR test for WordPress 6.4.2 with PHP 7.0, 7.4 and 8.0.
- Since there was changes gets merged and not bumping the version previously, we also need to taking care of it and bumping the version to `0.6.2` here.
- Related changes: https://github.com/WordPress/wpcat2tag-importer/pull/4

How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "7.0",
  "plugins": ["./wpcat2tag-importer"]
}
```
- Run `wp-env start` to spin up the WordPress
- Activate a theme that supports post format: http://localhost:8888/wp-admin/theme-install.php (filter with: Features -> "Post Formats")
- Create some tags, some categories, and some posts tagged with that
- Open http://localhost:8888/wp-admin/admin.php?import=wpcat2tag
- Try to convert tags to categories, categories to tags and etc. The plugin must load correctly and no errors displayed