### PR TITLE
Test plugin for WordPress 6.6.2 and fix minor issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -23,7 +23,7 @@ Convert existing categories to tags or tags to categories, selectively.
 == Changelog ==
 
 = 0.6.3 =
-* Testing the plugin up to WordPress 6.6.2
+* Testing the plugin up to WordPress 6.7
 * Fix minor issue on reference assign
 
 = 0.6.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 6.6.2
+Tested up to: 6.6
 Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, categories and tags converter
 Requires at least: 3.0
-Tested up to: 6.4.2
-Stable tag: 0.6.2
+Tested up to: 6.6.2
+Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ Convert existing categories to tags or tags to categories, selectively.
 1. Go to the Tools -> Import screen, Click on Categories and Tags Converter
 
 == Changelog ==
+
+= 0.6.3 =
+* Testing the plugin up to WordPress 6.6.2
+* Fix minor issue on reference assign
 
 = 0.6.2 =
 * Testing the plugin up to WordPress 6.4.2

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/wpcat2tag-importer/
 Description: Convert existing categories to tags or tags to categories, selectively.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.2
+Version: 0.6.3
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/wpcat2tag-importer.php
+++ b/wpcat2tag-importer.php
@@ -284,7 +284,7 @@ class WP_Categories_to_Tags extends WP_Importer {
 		echo '<ul>';
 
 		foreach ( $hier[$parent->term_id] as $child_id ) {
-			$child =& get_category($child_id);
+			$child = get_category($child_id);
 
 			echo '<li><label><input type="checkbox" name="cats_to_convert[]" value="'. intval($child->term_id) .'" /> ' . esc_html($child->name) . " ({$child->count})</label>";
 


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.6.2 and fixes the "Only variables should be assigned by reference" warning.

Tested with WordPress 6.6.2
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is blogger-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./wpcat2tag-importer"]
}
```
Run `wp-env start` to spin up the WordPress.

Create multiple tags and categories. Navigate to `http://localhost:8888/wp-admin/admin.php?import=wpcat2tag` and switch them. Check to see if the operation works without errors or warnings.